### PR TITLE
Add Deployment section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,8 @@ See [CHANGELOG.md](CHANGELOG.md)
 [Joi]: https://github.com/hapijs/joi
 [Express]: http://expressjs.com/
 
+## Deploy
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/chuyik/LeanCloud-Vue-Boilerplate)
+
 ## License
 [BSD license](http://opensource.org/licenses/bsd-license.php)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+build]
+  command = "npm run build"
+  publish = "dist"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
-build]
+[build]
   command = "npm run build"
   publish = "dist"


### PR DESCRIPTION
# What is this?

Simple deploy to Netlify button for stargazers to clone and deploy to check out live.

[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/LeanCloud-Vue-Boilerplate)

# Why?

Just think it would be a nice to have. Currently exploring Vue myself and checking out some of these projects. I also work for Netlify during the day, let me know if you have any questions about it. 